### PR TITLE
Updates for better usability as an OBS browser source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # APSpectator
 A web-based spectator client for Archipelago
+
+## Usage as a browser source (OBS, SLOBS, etc.)
+
+A handful of options exist to better enable using the spectator client as a
+browser source in OBS.
+
+The following URL parameters can be defined:
+
+- `server`: Archipelago server address, e.g. `example.org:38281`
+- `player`: Player name or slot number.
+- `password`: Server password (if required)
+- `hideui`: If set to 1, the entire spectator client UI will be hidden.  This means there will be no space to enter commands or enter connection information.
+
+If both `server` and `player` and specified, the client will automatically
+connect on page load.  Specifying just one of them has no effect currently.
+
+Example: `path/to/index.html?server=example.org&player=Yourname&password=topsecret&hideui=1`
+
+### CSS Overrides
+
+Using OBS, you can override the CSS used to style the client's output.  Here's a reasonably good starting point:
+
+```css
+body { background-color: rgba(0, 0, 0, 0); margin: 0px auto; overflow: hidden; }
+#main-content { border: 0; padding: 0; margin: 0; }
+#console-output-wrapper { overflow: hidden; }
+```
+
+To change the background color, add it to `#console-output-wrapper`.  Here's a translucent black background:
+
+```css
+#console-output-wrapper { overflow: hidden; background-color: rgba(0, 0, 0, 75%); }
+```
+
+You can change the styling for references to your name by styling `.cmsg-player-self`, other players with `.cmsg-player-other`, item names with `.cmsg-item`, and locations with `.cmsg-location`.  For more details, see `console.css`

--- a/README.md
+++ b/README.md
@@ -11,19 +11,21 @@ The following URL parameters can be defined:
 - `server`: Archipelago server address, e.g. `example.org:38281`
 - `player`: Player name or slot number.
 - `password`: Server password (if required)
-- `hideui`: If set to 1, the entire spectator client UI will be hidden.  This means there will be no space to enter commands or enter connection information.
+- `hideui`: If set to 1, the entire spectator client UI will be hidden. This means there will be no space to enter
+commands or enter connection information.
 
 If both `server` and `player` and specified, the client will automatically
 connect on page load.  Specifying just one of them has no effect currently.
 
-Example: `path/to/index.html?server=example.org&player=Yourname&password=topsecret&hideui=1`
+Example:  
+`path/to/index.html?server=example.org&player=Yourname&password=topsecret&hideui=1`
 
 ### CSS Overrides
 
 Using OBS, you can override the CSS used to style the client's output.  Here's a reasonably good starting point:
 
 ```css
-body { background-color: rgba(0, 0, 0, 0); margin: 0px auto; overflow: hidden; }
+body { background-color: rgba(0, 0, 0, 0); margin: 0 auto; overflow: hidden; }
 #main-content { border: 0; padding: 0; margin: 0; }
 #console-output-wrapper { overflow: hidden; }
 ```
@@ -34,4 +36,6 @@ To change the background color, add it to `#console-output-wrapper`.  Here's a t
 #console-output-wrapper { overflow: hidden; background-color: rgba(0, 0, 0, 75%); }
 ```
 
-You can change the styling for references to your name by styling `.cmsg-player-self`, other players with `.cmsg-player-other`, item names with `.cmsg-item`, and locations with `.cmsg-location`.  For more details, see `console.css`
+You can change the styling for references to your name by styling `.console-message-player-self`, other players with
+`.console-message-player-other`, item names with `.console-message-item`, and locations with `.console-message-location`.  For more details,
+see `console.css`

--- a/public/assets/console.js
+++ b/public/assets/console.js
@@ -4,21 +4,6 @@ const maxConsoleMessages = 500;
 let commandCursor = 0;
 
 window.addEventListener('load', () => {
-  var url = new URL(window.location)
-  var server = url.searchParams.get("server");
-  var player = url.searchParams.get("player");
-  var password = url.searchParams.get("password");
-  var hideUI = !!parseInt(url.searchParams.get("hideui"));
-
-  if(server && player) {
-    connectToServer(server, player, password);
-  }
-
-  if(hideUI) {
-    document.getElementById('header').classList.add('invisible');
-    document.getElementById('console-input-wrapper').classList.add('invisible');
-  }
-
   const commandInput = document.getElementById('console-input');
   commandInput.addEventListener('keydown', (event) => {
     // Only perform events on desired keys
@@ -151,18 +136,18 @@ const appendFormattedConsoleMessage = (messageParts) => {
         case 'player_id':
           const playerIsClient = parseInt(part.text, 10) === playerSlot;
           if (playerIsClient) {
-            span.classList.add("cmsg-player-self");
+            span.classList.add("console-message-player-self");
           } else {
-            span.classList.add("cmsg-player-other");
+            span.classList.add("console-message-player-other");
           }
           span.innerText = players[parseInt(part.text, 10) - 1].alias;
           break;
         case 'item_id':
-          span.classList.add("cmsg-item");
+          span.classList.add("console-message-item");
           span.innerText = apItemsById[Number(part.text)];
           break;
         case 'location_id':
-          span.classList.add("cmsg-location");
+          span.classList.add("console-message-location");
           span.innerText = apLocationsById[Number(part.text)];
           break;
         default:

--- a/public/assets/console.js
+++ b/public/assets/console.js
@@ -4,6 +4,21 @@ const maxConsoleMessages = 500;
 let commandCursor = 0;
 
 window.addEventListener('load', () => {
+  var url = new URL(window.location)
+  var server = url.searchParams.get("server");
+  var player = url.searchParams.get("player");
+  var password = url.searchParams.get("password");
+  var hideUI = !!parseInt(url.searchParams.get("hideui"));
+
+  if(server && player) {
+    connectToServer(server, player, password);
+  }
+
+  if(hideUI) {
+    document.getElementById('header').classList.add('invisible');
+    document.getElementById('console-input-wrapper').classList.add('invisible');
+  }
+
   const commandInput = document.getElementById('console-input');
   commandInput.addEventListener('keydown', (event) => {
     // Only perform events on desired keys

--- a/public/assets/console.js
+++ b/public/assets/console.js
@@ -150,16 +150,19 @@ const appendFormattedConsoleMessage = (messageParts) => {
       switch(part.type){
         case 'player_id':
           const playerIsClient = parseInt(part.text, 10) === playerSlot;
-          if (playerIsClient) { span.style.fontWeight = 'bold'; }
-          span.style.color = playerIsClient ? '#ffa565' : '#52b44c';
+          if (playerIsClient) {
+            span.classList.add("cmsg-player-self");
+          } else {
+            span.classList.add("cmsg-player-other");
+          }
           span.innerText = players[parseInt(part.text, 10) - 1].alias;
           break;
         case 'item_id':
-          span.style.color = '#fc5252';
+          span.classList.add("cmsg-item");
           span.innerText = apItemsById[Number(part.text)];
           break;
         case 'location_id':
-          span.style.color = '#5ea2c1';
+          span.classList.add("cmsg-location");
           span.innerText = apLocationsById[Number(part.text)];
           break;
         default:

--- a/public/assets/header.js
+++ b/public/assets/header.js
@@ -19,8 +19,8 @@ const setFontSize = (size) => {
 const toggleUi = () => {
   // SHow or hide the UI
   uiVisible ?
-    document.getElementById('header').classList.add('invisible') :
-    document.getElementById('header').classList.remove('invisible');
+    document.getElementById('header').classList.add('hidden') :
+    document.getElementById('header').classList.remove('hidden');
 
   // Toggle the UI state flag
   uiVisible = !uiVisible;

--- a/public/assets/serverSocket.js
+++ b/public/assets/serverSocket.js
@@ -22,6 +22,19 @@ window.addEventListener('load', () => {
   // Handle server address change
   document.getElementById('server-address').addEventListener('keydown', beginConnectionAttempt);
   document.getElementById('player').addEventListener('keydown', beginConnectionAttempt);
+
+  const url = new URL(window.location)
+  const server = url.searchParams.get('server');
+  const player = url.searchParams.get('player');
+
+  if(server && player) {
+    connectToServer(server, player, url.searchParams.get('password'));
+  }
+
+  if(!!parseInt(url.searchParams.get('hideui'))) {
+    document.getElementById('header').classList.add('hidden');
+    document.getElementById('console-input-wrapper').classList.add('hidden');
+  }
 });
 
 const beginConnectionAttempt = (event) => {
@@ -80,6 +93,8 @@ const connectToServer = (address, player, password = null) => {
 
   // Handle incoming messages
   serverSocket.onmessage = (event) => {
+    console.log(event);
+
     const commands = JSON.parse(event.data);
     for (let command of commands) {
       const serverStatus = document.getElementById('server-status');
@@ -88,10 +103,10 @@ const connectToServer = (address, player, password = null) => {
           // Authenticate with the server
           const connectionData = {
             cmd: 'Connect',
-            game: 'Archipelago',
+            game: null,
             name: player,
             uuid: getClientId(),
-            tags: ['TextOnly', 'IgnoreGame', 'Spectator'],
+            tags: ['TextOnly', 'Spectator'],
             password: serverPassword,
             version: ARCHIPELAGO_PROTOCOL_VERSION,
             items_handling: 0b000,

--- a/public/styles/console.css
+++ b/public/styles/console.css
@@ -28,3 +28,20 @@
     margin-left: 0.5rem;
     flex-grow: 100;
 }
+
+.cmsg-player-other {
+    color: #52b44c;
+}
+
+.cmsg-player-self {
+    color: #ffa565;
+    font-weight: bold;
+}
+
+.cmsg-item {
+    color: #fc5252;
+}
+
+.cmsg-location {
+    color: #5ea2c1;
+}

--- a/public/styles/console.css
+++ b/public/styles/console.css
@@ -24,24 +24,28 @@
     margin-top: 10px;
 }
 
+#console-input-wrapper.hidden{
+    display: none;
+}
+
 #console-input{
     margin-left: 0.5rem;
     flex-grow: 100;
 }
 
-.cmsg-player-other {
+.console-message-player-other {
     color: #52b44c;
 }
 
-.cmsg-player-self {
+.console-message-player-self {
     color: #ffa565;
     font-weight: bold;
 }
 
-.cmsg-item {
+.console-message-item {
     color: #fc5252;
 }
 
-.cmsg-location {
+.console-message-location {
     color: #5ea2c1;
 }

--- a/public/styles/header.css
+++ b/public/styles/header.css
@@ -3,8 +3,8 @@
     flex-direction: row;
 }
 
-#header.invisible{
-    display: none;
+.invisible{
+    display: none !important;
 }
 
 #header .connected{

--- a/public/styles/header.css
+++ b/public/styles/header.css
@@ -3,8 +3,8 @@
     flex-direction: row;
 }
 
-.invisible{
-    display: none !important;
+#header.hidden{
+    display: none;
 }
 
 #header .connected{


### PR DESCRIPTION
Per earlier discussions, this makes the following changes to make this easier to use as a browser source in OBS:

- Allow the UI to be _fully_ hidden (including command input) by specifying `?hideui=1` in the URL.  
- Allow connection information to be specified as URL parameters by specifying `server`, `player`, and optional `password` URL parameters.
- Colorize player names, item names and locations using CSS classes rather than hardcoded colors.

An updated README is included, with examples.

Known issue: This requires a browser that supports the `URLSearchParams` interface (as documented [here](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)), which is available in all modern browsers except IE.  So, in other words, it's available in all modern browsers.  I didn't bother to create a polyfill for it.