### PR TITLE
Add CSS classes for entrance hints and for item types

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,17 @@ To change the background color, add it to `#console-output-wrapper`.  Here's a t
 #console-output-wrapper { overflow: hidden; background-color: rgba(0, 0, 0, 75%); }
 ```
 
-You can change the styling for references to your name by styling `.cmsg-player-self`, other players with `.cmsg-player-other`, item names with `.cmsg-item`, and locations with `.cmsg-location`.  For more details, see `console.css`
+You can change other elements by styling the following CSS classes:
+
+| CSS Class            | Explanation
+| -------------------- | -----------
+| `.cmsg-player-self`  | Your player
+| `.cmsg-player-other` | Other players
+| `.cmsg-location`     | Location names
+| `.cmsg-item`         | Items (all types)
+| `.item-advancement`  | Advancement items
+| `.item-useful`       | Useful items
+| `.item-trap`         | Trap items
+| `.cmsg-entrance`     | Entrance names (seen in hints)
+
+For more details, see [console.css](public/styles/console.css).  For a sample that updates colors to match common client colors, see [commonclient.css](public/styles/commonclient.css) 

--- a/public/assets/console.js
+++ b/public/assets/console.js
@@ -159,11 +159,29 @@ const appendFormattedConsoleMessage = (messageParts) => {
           break;
         case 'item_id':
           span.classList.add("cmsg-item");
+          if(part.flags & 0b001) {
+            span.classList.add("item-advancement");
+            span.setAttribute("title", "Advancement Item")
+          }
+          if(part.flags & 0b010) {
+            span.classList.add("item-useful");
+            span.setAttribute("title", "Useful Item")
+          }
+          if(part.flags & 0b100) {
+            span.classList.add("item-trap");
+            span.setAttribute("title", "Trap")
+          }
           span.innerText = apItemsById[Number(part.text)];
+
+          console.log(part)
           break;
         case 'location_id':
           span.classList.add("cmsg-location");
           span.innerText = apLocationsById[Number(part.text)];
+          break;
+        case 'entrance_name':
+          span.classList.add("cmsg-entrance");
+          span.innerText = part.text;
           break;
         default:
           span.innerText = part.text;

--- a/public/styles/commonclient.css
+++ b/public/styles/commonclient.css
@@ -1,0 +1,32 @@
+/*
+This CSS isn't used anywhere... but the colors listed here match the Archipelago Common Client colors.
+
+You can use this to override the default Spectator Client e.g. in OBS.
+ */
+
+.cmsg-player-other {
+    color: #FAFAD2;
+}
+.cmsg-player-self {
+    color: #EE00EE;
+    font-weight: bold;
+}
+.cmsg-item {
+    color: #00EEEE;
+}
+.cmsg-location {
+    color: #00FF7F;
+}
+.cmsg-entrance {
+    color: #6495ED;
+}
+
+.item-advancement {
+    color: #AF99EF;
+}
+.item-useful {
+    color: #6D8BE8;
+}
+.item-trap {
+    color: #FA8072;
+}

--- a/public/styles/console.css
+++ b/public/styles/console.css
@@ -45,3 +45,10 @@
 .cmsg-location {
     color: #5ea2c1;
 }
+
+/* These aren't styled in the default CSS, but are listed here for reference */
+/*
+.item-advancement { color: #AF99EF; }
+.item-useful { color: #6D8BE8;}
+.item-trap { color: #FA8072; }
+*/


### PR DESCRIPTION
- Adds CSS classes for entrance hints
- Adds CSS classes for item types (advancement/useful/trap)
- Adds a sample CSS file that matches CommonClient default colors and reference it in README.md
- Update README.md

These changes will be primarily of interest to OBS users and others doing CSS overrides; they're invisible to everyone else.